### PR TITLE
Fix TypeError for exception on bad response from server

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -29,7 +29,7 @@ def _make_request(url, username, password, ssl_verify):
         url, auth=(args.api_username, args.api_password), verify=ssl_verify
     )
     if response.status_code != HTTPStatus.OK:
-        raise ValueError("bad response from server: %s" % response.status_code)
+        raise RuntimeError("bad response from server: %s" % response.status_code)
     result = response.json()
     if "data" in result and len(result["data"]) == 0:
         raise RuntimeError("no results found for request")

--- a/diff.py
+++ b/diff.py
@@ -29,7 +29,7 @@ def _make_request(url, username, password, ssl_verify):
         url, auth=(args.api_username, args.api_password), verify=ssl_verify
     )
     if response.status_code != HTTPStatus.OK:
-        raise "bad response from server: %s" % response.status_code
+        raise ValueError("bad response from server: %s" % response.status_code)
     result = response.json()
     if "data" in result and len(result["data"]) == 0:
         raise RuntimeError("no results found for request")


### PR DESCRIPTION
I am getting the following exception:

```
/home/jmarc/anaconda3/lib/python3.7/site-packages/urllib3/connectionpool.py:1004: InsecureRequestWarning: Unverified HTTPS request is being made to host 'ci.cloud.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
Traceback (most recent call last):
  File "diff.py.1", line 205, in <module>
    args.ssl_verify,
  File "diff.py.1", line 32, in _make_request
    raise "bad response from server: %s" % response.status_code
TypeError: exceptions must derive from BaseException
```